### PR TITLE
Cache setPosition() value if DeviceStatus is not READY. Fixes #11

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/GoBildaPinpointDriver.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/GoBildaPinpointDriver.java
@@ -513,7 +513,7 @@ public class GoBildaPinpointDriver extends I2cDeviceSynchDevice<I2cDeviceSynchSi
      * Send a position that the Pinpoint should use to track your robot relative to.
      * You can use this to update the estimated position of your robot with new external
      * sensor data, or to run a robot in field coordinates.
-     * @param posX the new X position you'd like the Pinpoint to track your robot relive to.
+     * @param posX the new X position you'd like the Pinpoint to track your robot relative to.
      * @param distanceUnit the unit for posX
      */
     public void setPosX(double posX, DistanceUnit distanceUnit){
@@ -524,7 +524,7 @@ public class GoBildaPinpointDriver extends I2cDeviceSynchDevice<I2cDeviceSynchSi
      * Send a position that the Pinpoint should use to track your robot relative to.
      * You can use this to update the estimated position of your robot with new external
      * sensor data, or to run a robot in field coordinates.
-     * @param posY the new Y position you'd like the Pinpoint to track your robot relive to.
+     * @param posY the new Y position you'd like the Pinpoint to track your robot relative to.
      * @param distanceUnit the unit for posY
      */
     public void setPosY(double posY, DistanceUnit distanceUnit){
@@ -535,7 +535,7 @@ public class GoBildaPinpointDriver extends I2cDeviceSynchDevice<I2cDeviceSynchSi
      * Send a heading that the Pinpoint should use to track your robot relative to.
      * You can use this to update the estimated position of your robot with new external
      * sensor data, or to run a robot in field coordinates.
-     * @param heading the new heading you'd like the Pinpoint to track your robot relive to.
+     * @param heading the new heading you'd like the Pinpoint to track your robot relative to.
      * @param angleUnit Radians or Degrees
      */
     public void setHeading(double heading, AngleUnit angleUnit){

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/GoBildaPinpointDriver.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/GoBildaPinpointDriver.java
@@ -47,7 +47,7 @@ import java.util.Arrays;
         name = "goBILDA® Pinpoint Odometry Computer",
         xmlTag = "goBILDAPinpoint",
         description ="goBILDA® Pinpoint Odometry Computer (IMU Sensor Fusion for 2 Wheel Odometry)"
-        )
+)
 
 public class GoBildaPinpointDriver extends I2cDeviceSynchDevice<I2cDeviceSynchSimple> {
 
@@ -64,6 +64,8 @@ public class GoBildaPinpointDriver extends I2cDeviceSynchDevice<I2cDeviceSynchSi
 
     private static final float goBILDA_SWINGARM_POD = 13.26291192f; //ticks-per-mm for the goBILDA Swingarm Pod
     private static final float goBILDA_4_BAR_POD    = 19.89436789f; //ticks-per-mm for the goBILDA 4-Bar Pod
+
+    private static volatile Pose2D cachedSetPositionValue = null;
 
     //i2c address of the device
     public static final byte DEFAULT_ADDRESS = 0x31;
@@ -157,7 +159,7 @@ public class GoBildaPinpointDriver extends I2cDeviceSynchDevice<I2cDeviceSynchSi
 
 
     /** Writes an int to the i2c device
-    @param reg the register to write the int to
+     @param reg the register to write the int to
      @param i the integer to write to the register
      */
     private void writeInt(final Register reg, int i){
@@ -245,6 +247,10 @@ public class GoBildaPinpointDriver extends I2cDeviceSynchDevice<I2cDeviceSynchSi
             return DeviceStatus.FAULT_IMU_RUNAWAY;
         }
         if ((s & DeviceStatus.READY.status) != 0){
+            if(cachedSetPositionValue != null){
+                setPosition(cachedSetPositionValue);
+                cachedSetPositionValue = null;
+            }
             return DeviceStatus.READY;
         }
         if ((s & DeviceStatus.FAULT_BAD_READ.status) != 0){
@@ -334,6 +340,7 @@ public class GoBildaPinpointDriver extends I2cDeviceSynchDevice<I2cDeviceSynchSi
         yVelocity    = isVelocityCorrupt(oldVelY, yVelocity, velocityThreshold);
         hVelocity    = isVelocityCorrupt(oldVelH, hVelocity, headingVelocityThreshold);
 
+        getDeviceStatus();
     }
 
     /**
@@ -491,10 +498,15 @@ public class GoBildaPinpointDriver extends I2cDeviceSynchDevice<I2cDeviceSynchSi
      * @param pos a Pose2D describing the robot's new position.
      */
     public Pose2D setPosition(Pose2D pos){
-        writeByteArray(Register.X_POSITION,(floatToByteArray((float) pos.getX(DistanceUnit.MM), ByteOrder.LITTLE_ENDIAN)));
-        writeByteArray(Register.Y_POSITION,(floatToByteArray((float) pos.getY(DistanceUnit.MM),ByteOrder.LITTLE_ENDIAN)));
-        writeByteArray(Register.H_ORIENTATION,(floatToByteArray((float) pos.getHeading(AngleUnit.RADIANS),ByteOrder.LITTLE_ENDIAN)));
-        return pos;
+        if(getDeviceStatus() != DeviceStatus.READY){
+            cachedSetPositionValue = pos;
+            return getPosition();
+        }else {
+            writeByteArray(Register.X_POSITION, (floatToByteArray((float) pos.getX(DistanceUnit.MM), ByteOrder.LITTLE_ENDIAN)));
+            writeByteArray(Register.Y_POSITION, (floatToByteArray((float) pos.getY(DistanceUnit.MM), ByteOrder.LITTLE_ENDIAN)));
+            writeByteArray(Register.H_ORIENTATION, (floatToByteArray((float) pos.getHeading(AngleUnit.RADIANS), ByteOrder.LITTLE_ENDIAN)));
+            return pos;
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary

This PR addresses an initialization issue with the goBILDA® Pinpoint Odometry Computer driver. Previously, calls to `setPosition()` made before the device was fully initialized ("READY" state) were dropped and never applied. This fix ensures all position updates are deferred and automatically executed as soon as the device becomes ready.

## Changes

- Added a cached deferred position (`cachedSetPositionValue`) that stores `setPosition()` arguments if the device is not ready.
- On each status update, if the device transitions to "READY", the cached position is automatically applied and the cache is cleared.
- No blocking or thread waiting required; the control loop remains responsive.

## Impact

- Initialization code and autonomous routines can safely call `setPosition()` at any time, even before the Pinpoint device is ready.
- The robot's starting pose is reliably set as soon as the hardware is ready.
- No risk of lost setPosition commands, no need for user code to track device status manually.

## Testing

- Verified by calling `setPosition()` before device initialization and confirming the position is set once the device is ready.
- Confirmed that multiple calls to `setPosition()` before readiness result in only the latest position being applied.

## Related Issues

- Fixes [Dropped setPosition() calls when the pinpoint is not fully initialized](https://github.com/goBILDA-Official/FtcRobotController-Add-Pinpoint/issues/11)

## Notes

If you want to be notified when a deferred position is applied, consider adding a log statement inside the deferred logic.
