### PR TITLE
Fix for #17 getHeading(AngleUnit)

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/GoBildaPinpointDriver.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/GoBildaPinpointDriver.java
@@ -638,7 +638,7 @@ public class GoBildaPinpointDriver extends I2cDeviceSynchDevice<I2cDeviceSynchSi
      * normalized heading is wrapped from -180°, to 180°.
      */
     public double getHeading(AngleUnit angleUnit){
-        return angleUnit.fromRadians((hOrientation + Math.PI) % (2 * Math.PI) + 2 * Math.PI) % (2 * Math.PI) - Math.PI;
+        return angleUnit.fromRadians(((hOrientation + Math.PI) % (2 * Math.PI) + 2 * Math.PI) % (2 * Math.PI) - Math.PI);
     }
 
     /**


### PR DESCRIPTION
Code changes to address issue https://github.com/goBILDA-Official/FtcRobotController-Add-Pinpoint/issues/17.

"getHeading(AngleUnit) always normalizes to the range of radians even when degrees are specified."

Fixed the issue where part of the normalization is happening before passing the value and the rest on the returned value.